### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: macos-26


### PR DESCRIPTION
Potential fix for [https://github.com/craigjbass/clearancekit/security/code-scanning/1](https://github.com/craigjbass/clearancekit/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block for the workflow or job so that the GITHUB_TOKEN has only the minimal scopes required. Since this workflow only checks out code and runs `xcodebuild test`, it only needs read access to the repository contents.

The best minimal change without affecting existing behavior is to add a root-level `permissions` block (applies to all jobs) specifying `contents: read`. This documents the intended permissions, ensures they remain restricted regardless of repo/org defaults, and satisfies CodeQL’s recommendation. Concretely, in `.github/workflows/pr-test.yml`, insert:

```yml
permissions:
  contents: read
```

between the `on:` block (lines 3–6) and the `jobs:` block (line 8). No additional imports or methods are needed, as this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
