### PR TITLE
Add SLSA L3 provenance and Sigstore bundle to release assets

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,6 +12,9 @@ jobs:
       id-token: write
       contents: write
       attestations: write
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
+      release_name: ${{ steps.version.outputs.name }}
 
     steps:
       - name: Checkout
@@ -154,16 +157,48 @@ jobs:
           xcrun stapler staple "build/clearancekit-${{ steps.version.outputs.name }}.dmg"
 
       - name: Attest build provenance
+        id: attest
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: build/clearancekit-${{ steps.version.outputs.name }}.dmg
 
+      - name: Stage Sigstore bundle as release asset
+        env:
+          VERSION_NAME: ${{ steps.version.outputs.name }}
+        run: |
+          cp "${{ steps.attest.outputs.bundle-path }}" \
+             "build/clearancekit-${VERSION_NAME}.dmg.sigstore"
+
+      - name: Compute artifact hashes for SLSA provenance
+        id: hash
+        env:
+          VERSION_NAME: ${{ steps.version.outputs.name }}
+        run: |
+          cd build
+          HASHES=$(shasum -a 256 "clearancekit-${VERSION_NAME}.dmg" | base64 | tr -d '\n')
+          echo "hashes=${HASHES}" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub pre-release
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION_NAME: ${{ steps.version.outputs.name }}
         run: |
-          gh release create "${{ steps.version.outputs.name }}" \
-            "build/clearancekit-${{ steps.version.outputs.name }}.dmg" \
+          gh release create "$VERSION_NAME" \
+            "build/clearancekit-${VERSION_NAME}.dmg" \
+            "build/clearancekit-${VERSION_NAME}.dmg.sigstore" \
             --prerelease \
             --generate-notes \
-            --title "${{ steps.version.outputs.name }}"
+            --title "$VERSION_NAME"
+
+  provenance:
+    needs: build-and-notarize
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: ${{ needs.build-and-notarize.outputs.hashes }}
+      upload-assets: true
+      upload-tag-name: ${{ needs.build-and-notarize.outputs.release_name }}
+      provenance-name: clearancekit-${{ needs.build-and-notarize.outputs.release_name }}.dmg.intoto.jsonl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
       attestations: write  # required for attest-build-provenance
     env:
       TAG_NAME: ${{ github.ref_name }}
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
 
     steps:
       - name: Checkout
@@ -142,9 +144,22 @@ jobs:
           xcrun stapler staple "build/clearancekit-${TAG_NAME}.dmg"
 
       - name: Attest build provenance
+        id: attest
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: build/clearancekit-${{ github.ref_name }}.dmg
+
+      - name: Stage Sigstore bundle as release asset
+        run: |
+          cp "${{ steps.attest.outputs.bundle-path }}" \
+             "build/clearancekit-${TAG_NAME}.dmg.sigstore"
+
+      - name: Compute artifact hashes for SLSA provenance
+        id: hash
+        run: |
+          cd build
+          HASHES=$(shasum -a 256 "clearancekit-${TAG_NAME}.dmg" | base64 | tr -d '\n')
+          echo "hashes=${HASHES}" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub release
         env:
@@ -152,5 +167,19 @@ jobs:
         run: |
           gh release create "$TAG_NAME" \
             "build/clearancekit-${TAG_NAME}.dmg" \
+            "build/clearancekit-${TAG_NAME}.dmg.sigstore" \
             --generate-notes \
             --title "$TAG_NAME"
+
+  provenance:
+    needs: build-and-notarize
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: ${{ needs.build-and-notarize.outputs.hashes }}
+      upload-assets: true
+      upload-tag-name: ${{ github.ref_name }}
+      provenance-name: clearancekit-${{ github.ref_name }}.dmg.intoto.jsonl


### PR DESCRIPTION
## Summary

- Upload the `.sigstore` bundle from `actions/attest-build-provenance@v2` as a release asset so Scorecard's Signed-Releases check can see it
- Add an isolated `provenance` job calling `slsa-framework/slsa-github-generator`'s generic SLSA3 reusable workflow, producing an `.intoto.jsonl` alongside each release for a legitimate SLSA Build L3 claim
- Apply to both `release.yml` (tag-triggered) and `prerelease.yml` (main-branch triggered)

## Why two attestations?

The inline `attest-build-provenance` step and the reusable SLSA generator workflow serve different purposes:

| | attest-build-provenance (inline) | slsa-github-generator (reusable) |
|---|---|---|
| Verification | `gh attestation verify` | `slsa-verifier verify-artifact` |
| Isolation | Same job as builder | Isolated builder job (SLSA L3 requirement) |
| Storage | GitHub API + `.sigstore` asset | `.intoto.jsonl` asset |

Keeping both gives consumers either verification path and lets us honestly claim SLSA Build L3, which the inline action alone cannot.

## Job ordering

`provenance` uses `needs: build-and-notarize`, so it runs only after the DMG is built, notarized, and the release exists. It then appends the `.intoto.jsonl` to the existing release via `upload-assets: true`.

## Test plan

- [ ] Push a test tag (e.g. `v0.0.0-slsa-test`) and confirm the release contains:
  - `clearancekit-<tag>.dmg`
  - `clearancekit-<tag>.dmg.sigstore`
  - `clearancekit-<tag>.dmg.intoto.jsonl`
- [ ] `gh attestation verify clearancekit-<tag>.dmg --repo craigjbass/clearancekit` succeeds
- [ ] `slsa-verifier verify-artifact clearancekit-<tag>.dmg --provenance-path clearancekit-<tag>.dmg.intoto.jsonl --source-uri github.com/craigjbass/clearancekit --source-tag <tag>` succeeds
- [ ] Next Scorecard weekly run reports Signed-Releases 10/10
- [ ] Delete the test tag/release afterwards

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)